### PR TITLE
Support latest Buffer implementation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,12 @@ var SSPInstance = Class.extend({
           }
           port.on('data', function (buffer) {
             if (buffer[0] === 0x7F) {
-              var data = buffer.toJSON().splice(3, buffer[2]);
+              var data = buffer.toJSON()
+              if (data.data) {
+                data = data.data.splice(3, buffer[2]);
+              } else {
+                data = data.splice(3, buffer[2]);
+              }
               var error = new Error("New error");
               error.code = data[0];
               switch (data[0]) {


### PR DESCRIPTION
According to https://nodejs.org/api/buffer.html `Buffer.toJson()` results in
`{"type":"Buffer","data":[116,101,115,116]}` so you have to invoke **splice** on `data` property.
